### PR TITLE
add option to print all units

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ hdate.prettyPrint(new Date(1416448704578), { showTime: true })
     - __pastSuffix `string`__ default: `"from now"`
     - __presentText `string`__ default: `"now"`
     - __returnObject `boolean`__: default: `false`
+    - __allUnits `boolean`__: default: `false`
 
 ##### Returns:
 
@@ -97,6 +98,9 @@ hdate.relativeTime(new Date("8-16-1987"))
 
 hdate.relativeTime(new Date("8-16-1987"), {returnObject: true})
 // { seconds: 31, minutes: 5, hours: 4, days: 101, years: 27, past: true }
+
+hdate.relativeTime(75, {allUnits: true})
+// 1 minute, 15 seconds from now
 ```
 
 #### .monthName(datestring or jsdate or monthnum)

--- a/humandate.js
+++ b/humandate.js
@@ -82,7 +82,7 @@
       showNext = true;
       function append(amount, string) {
         if (showNext) {
-          showNext = false;
+          showNext = options.allUnits;
           output.push(amount + ' ' + string + (amount > 1 ? 's' : ''));
         }
       }

--- a/test.js
+++ b/test.js
@@ -48,6 +48,9 @@ describe('relativeTime', function () {
     it('should work returning an object', function () {
       assert.equal(typeof hdate.relativeTime(-4, { returnObject: true }), 'object')
     })
+    it('should work with all units option', function () {
+      assert.equal(hdate.relativeTime(75, { allUnits: true }), '1 minute, 15 seconds from now')
+    })
   })
 })
 


### PR DESCRIPTION
Currently, `hdate.relativeTime(75)` will print `1 minute from now`, with no ability to include the remaining seconds. This adds an option to allow all non-zero units to be printed, `hdate.relativeTime(75, { allUnits: true })`.