### PR TITLE
Fix output when input time is less than a second

### DIFF
--- a/humandate.js
+++ b/humandate.js
@@ -75,7 +75,7 @@
       if (options.returnObject) {
         return time;
       }
-      if(seconds === 0) {
+      if(seconds < 1) {
         return options.presentText;
       }
       suffix = time.past ? options.pastSuffix : options.futureSuffix;

--- a/test.js
+++ b/test.js
@@ -34,6 +34,9 @@ describe('relativeTime', function () {
     it('should work with a date object', function () {
       assert.equal(hdate.relativeTime(new Date()), 'now')
     })
+    it('should work with a string', function () {
+      assert.equal(hdate.relativeTime(new Date().toString()), 'now');
+    });
   })
   describe('options', function () {
     it('should work with an optional future suffix', function () {


### PR DESCRIPTION
- Fixes #9 

Note: I think it made more sense to consider times "less than a second" to be more or less "now". There is always going to be an elapsed time between invocation and output so the concept of now has to be loose anyway. 